### PR TITLE
修改定位的属性名称错误拼写

### DIFF
--- a/OpenIMSDK/Model/OIMLocationElem.m
+++ b/OpenIMSDK/Model/OIMLocationElem.m
@@ -11,6 +11,6 @@
 @synthesize description;
 
 + (NSDictionary *)mj_replacedKeyFromPropertyName {
-    return @{@"desc" : @"desciption"};
+    return @{@"desc" : @"description"};
 }
 @end


### PR DESCRIPTION
@"desciption" 改为 @"description"